### PR TITLE
Added headers referring to the licence

### DIFF
--- a/lib/commontypes.c
+++ b/lib/commontypes.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Bálint Aradi, Universität Bremen. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
 #include <stdlib.h>
 #include <string.h>
 

--- a/lib/commontypes.h
+++ b/lib/commontypes.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Bálint Aradi, Universität Bremen. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
 #ifndef SAYDX_COMMONTYPES_H
 #define SAYDX_COMMONTYPES_H
 

--- a/lib/eventhandler.h
+++ b/lib/eventhandler.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Bálint Aradi, Universität Bremen. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
 #ifndef SAYDX_EVENTHANDLER_H
 #define SAYDX_EVENTHANDLER_H
 

--- a/lib/eventprinter.c
+++ b/lib/eventprinter.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Bálint Aradi, Universität Bremen. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
 #include <stdlib.h>
 #include "eventprinter.h"
 

--- a/lib/eventprinter.h
+++ b/lib/eventprinter.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Bálint Aradi, Universität Bremen. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
 #ifndef SAYDX_EVENTPRINTER_H
 #define SAYDX_EVENTPRINTER_H
 

--- a/lib/msdparser.c
+++ b/lib/msdparser.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Bálint Aradi, Universität Bremen. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/lib/msdparser.h
+++ b/lib/msdparser.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Bálint Aradi, Universität Bremen. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
 #ifndef SAYDX_MSDPARSER_H
 #define SAYDX_MSDPARSER_H
 

--- a/lib/node.c
+++ b/lib/node.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Bálint Aradi, Universität Bremen. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
 #include <stdlib.h>
 #include <string.h>
 #include "node.h"

--- a/lib/node.h
+++ b/lib/node.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Bálint Aradi, Universität Bremen. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
 #ifndef SAYDX_NODE_H
 #define SAYDX_NODE_H
 

--- a/lib/treebuilder.c
+++ b/lib/treebuilder.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Bálint Aradi, Universität Bremen. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
 #include <stdlib.h>
 #include <string.h>
 #include "treebuilder.h"

--- a/lib/treebuilder.h
+++ b/lib/treebuilder.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Bálint Aradi, Universität Bremen. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
 #ifndef SAYDX_TREEBUILDER_H
 #define SAYDX_TREEBUILDER_H
 

--- a/lib/treewalker.c
+++ b/lib/treewalker.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Bálint Aradi, Universität Bremen. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
 #include "treewalker.h"
 #include "eventprinter.h"
 #include "treebuilder.h"

--- a/lib/treewalker.h
+++ b/lib/treewalker.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Bálint Aradi, Universität Bremen. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
 #ifndef SAYDX_TREEWALKER_H
 #define SAYDX_TREEWALKER_H
 

--- a/test/test1.c
+++ b/test/test1.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2020 Bálint Aradi, Universität Bremen. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
 #include "commontypes.h"
 #include "msdparser.h"
 #include "eventprinter.h"


### PR DESCRIPTION
Used the https://github.com/google/addlicense tool. Seems to be common practice to add licence ref headers.